### PR TITLE
Fix invalid token error by removing empty env string

### DIFF
--- a/OPENROUTER_SETUP.md
+++ b/OPENROUTER_SETUP.md
@@ -22,7 +22,7 @@ Set the following environment variables:
 
 ```bash
 export LLM_PROVIDER="openrouter"
-export OPENROUTER_API_KEY="sk-or-your-api-key-here"
+export OPENROUTER_API_KEY=sk-or-your-api-key-here
 export OPENROUTER_MODEL="openai/gpt-3.5-turbo"
 ```
 
@@ -47,21 +47,21 @@ Run the bot and try the `/start` command. If everything is configured correctly,
 ### Basic Setup
 ```bash
 export LLM_PROVIDER="openrouter"
-export OPENROUTER_API_KEY="sk-or-your-key"
+export OPENROUTER_API_KEY=sk-or-your-key
 export OPENROUTER_MODEL="openai/gpt-3.5-turbo"
 ```
 
 ### Using Claude
 ```bash
 export LLM_PROVIDER="openrouter"
-export OPENROUTER_API_KEY="sk-or-your-key"
+export OPENROUTER_API_KEY=sk-or-your-key
 export OPENROUTER_MODEL="anthropic/claude-3-haiku"
 ```
 
 ### Using Gemini
 ```bash
 export LLM_PROVIDER="openrouter"
-export OPENROUTER_API_KEY="sk-or-your-key"
+export OPENROUTER_API_KEY=sk-or-your-key
 export OPENROUTER_MODEL="google/gemini-pro"
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ A text-based RPG adventure bot for Telegram that acts as a Mini Dungeon Master, 
    Create a `.env` file or set environment variables:
    ```bash
    # Required
-   export TELEGRAM_TOKEN="your_telegram_bot_token_here"
+   export TELEGRAM_TOKEN=your_telegram_bot_token_here
    
    # Optional - LLM Configuration
    export LLM_PROVIDER="ollama"  # or "openrouter" or "openai"
    export OLLAMA_BASE_URL="http://localhost:11434"
    export OLLAMA_MODEL="llama2"
-   export OPENROUTER_API_KEY="your_openrouter_api_key"
+   export OPENROUTER_API_KEY=your_openrouter_api_key
    export OPENROUTER_MODEL="openai/gpt-3.5-turbo"
-   export OPENAI_API_KEY="your_openai_api_key"
+   export OPENAI_API_KEY=your_openai_api_key
    export OPENAI_MODEL="gpt-3.5-turbo"
    
    # Optional - Database
@@ -90,7 +90,7 @@ The bot can work with or without an LLM. If no LLM is available, it uses fallbac
 2. Set environment variables:
    ```bash
    export LLM_PROVIDER="openrouter"
-   export OPENROUTER_API_KEY="your_api_key"
+   export OPENROUTER_API_KEY=your_api_key
    export OPENROUTER_MODEL="openai/gpt-3.5-turbo"  # or any other model
    ```
 
@@ -99,7 +99,7 @@ The bot can work with or without an LLM. If no LLM is available, it uses fallbac
 2. Set environment variables:
    ```bash
    export LLM_PROVIDER="openai"
-   export OPENAI_API_KEY="your_api_key"
+   export OPENAI_API_KEY=your_api_key
    ```
 
 ## Game Mechanics

--- a/config.py
+++ b/config.py
@@ -6,12 +6,18 @@ import os
 from typing import Dict, Any
 
 # Telegram Bot Configuration
+# Note: When setting TELEGRAM_TOKEN in environment, do NOT include quotes
+# Correct: export TELEGRAM_TOKEN=your_token_here
+# Wrong:   export TELEGRAM_TOKEN="your_token_here"
 TELEGRAM_TOKEN = os.getenv('TELEGRAM_TOKEN', 'your_telegram_bot_token_here')
 
 # LLM Configuration
 LLM_PROVIDER = os.getenv('LLM_PROVIDER', 'ollama')  # 'ollama', 'openrouter', or 'openai'
 OLLAMA_BASE_URL = os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434')
 OLLAMA_MODEL = os.getenv('OLLAMA_MODEL', 'llama2')
+# Note: When setting API keys in environment, do NOT include quotes
+# Correct: export OPENROUTER_API_KEY=your_key_here
+# Wrong:   export OPENROUTER_API_KEY="your_key_here"
 OPENROUTER_API_KEY = os.getenv('OPENROUTER_API_KEY', '')
 OPENROUTER_MODEL = os.getenv('OPENROUTER_MODEL', 'openai/gpt-3.5-turbo')
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')


### PR DESCRIPTION
Remove quotes from environment variable exports in documentation and add configuration notes to prevent "invalid token" errors.

When environment variables are set using `export VAR="value"` in bash, the quotes become part of the variable's value. This caused tokens and API keys to be read with leading/trailing quotes, making them invalid for the bot. This PR updates the documentation to show the correct way to export variables (e.g., `export VAR=value`) and adds comments in `config.py` to guide users.

---
<a href="https://cursor.com/background-agent?bcId=bc-d01eda22-d876-43bd-bb75-32ec35be0b05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d01eda22-d876-43bd-bb75-32ec35be0b05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

